### PR TITLE
chore: Simplify mnemonic path drawing to save 45% storage

### DIFF
--- a/serena/Kana/Sources/Kana/KanaMnemonics/KanaMnemonicsPage.swift
+++ b/serena/Kana/Sources/Kana/KanaMnemonics/KanaMnemonicsPage.swift
@@ -144,8 +144,10 @@ struct MnemonicDrawingView: View {
                 path.addPath(drawnPath)
             }
         }
+        let simplified = pathToSave.description
+            .replacingOccurrences(of: #"(\d+)\.\d+"#, with: "$1", options: .regularExpression)
 
-        kanaMnemonicsPaths[data.kanaString] = pathToSave.description
+        kanaMnemonicsPaths[data.kanaString] = simplified
         UserDefaults.standard.set(kanaMnemonicsPaths, forKey: "kana-mnemonic-paths")
         dismiss()
     }


### PR DESCRIPTION
Drop the sub pixel decimals, we won't see them, this helps us remove about 3 digits for every point which ends up making quite a substantial difference