### PR TITLE
Visual fixups

### DIFF
--- a/serena/DesignSystem/Sources/DesignSystem/Modifiers/RegisterBaseTypography.swift
+++ b/serena/DesignSystem/Sources/DesignSystem/Modifiers/RegisterBaseTypography.swift
@@ -8,7 +8,7 @@ public func registerFontForUIKitComponents() {
     let navBarFont = fontConvertible.font(typography: .headline)
     let buttonFont = fontConvertible.font(typography: .body)
     let tabBarFont = fontConvertible.font(typography: .caption)
-    let segmentedControlFont = fontConvertible.font(typography: .callout)
+    let segmentedControlFont = fontConvertible.font(typography: .caption)
 
     let navBarAppearance = UINavigationBarAppearance()
     let buttonAppearance = UIBarButtonItemAppearance()

--- a/serena/Kana/Sources/Kana/KanaTraining/AllInARow/AllInARowExercicePage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/AllInARow/AllInARowExercicePage.swift
@@ -38,7 +38,7 @@ struct AllInARowExercicePage: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 10) {
-                ProgressView(progress: $progress)
+                ProgressBarView(progress: $progress)
                 Text(localized("Write the writing of all kanas in a row"))
 
                 VStack {
@@ -58,8 +58,6 @@ struct AllInARowExercicePage: View {
                         }
                     Text(info)
                 }
-
-                Spacer()
 
                 ZStack(alignment: .trailing) {
                     TextEditor(text: $inputText)

--- a/serena/Kana/Sources/Kana/KanaTraining/AllInARow/CompletedAllInARowPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/AllInARow/CompletedAllInARowPage.swift
@@ -120,7 +120,7 @@ struct CompletedAllInARowPage: View {
             if result.failedKanas.count != 0 {
                 Toggle(isOn: $shouldShowRomajiForFailedKanas) {
                     Text("Show Romaji for failed")
-                }
+                }.padding()
             }
         }
     }
@@ -141,7 +141,7 @@ struct ResultTileView: View {
                 Text(kana.kanaValue)
                 if shouldShowRomaji {
                     Text(kana.romajiValue)
-                        .typography(.caption)
+                        .typography(.callout)
                 }
             }
         })

--- a/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/FastSelectPopoverView.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/FastSelectPopoverView.swift
@@ -67,7 +67,7 @@ struct FastSelectToggleButton: View {
         }) {
             HStack {
                 Image(systemName: isOn ? "checkmark.circle.fill" : "checkmark.circle")
-                    .tint(isOn ? .mint : .gray)
+                    .tint(isOn ? .green : .gray)
                 Text(title)
 
                     .tint(.primary)

--- a/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaLineView.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaLineView.swift
@@ -22,14 +22,20 @@ struct KanaLineView: View {
                         KanaWritingPreview(text: kana, showRomaji: showRomaji, kanaSelectionType: kanaSelectionType)
                             .padding(.all, 6)
                             .frame(maxWidth: .infinity)
-                            .background { Color(white: 0.97) }
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .background { isOn ? Color(white: 1) : Color(white: 0.96) }
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                             .opacity(kana == nil ? 0 : 1)
                     }
                 }
                 .padding(.all, 4)
                 .foregroundStyle(isOn ? Color(white: 0.2) : Color(white: 0.4))
-                .background { isOn ? Color(white: 0.7) : Color(white: 0.92) }
+                .background { Color(white: 0.92) }
+                .overlay {
+                    if isOn {
+                        RoundedRectangle(cornerRadius: 8).stroke(lineWidth: 8)
+                            .fill(Color.gray.opacity(0.7))
+                    }
+                }
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(alignment: .topTrailing) {
                     if isOn {

--- a/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaSelectionPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaSelectionPage.swift
@@ -178,19 +178,14 @@ struct BottomViews: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            ZStack {
+            HStack {
+                Picker(localized("Training mode"), selection: $kanaSelectionType) {
+                    ForEach(KanaSelectionType.allCases, id: \.self) { Text(localized($0.rawValue)) }
+                }
+                .pickerStyle(.segmented)
                 Button(localized("Let's go ! %lld", totalSelectedKanas), action: onExerciceSelectionTapped)
                     .buttonStyle(.borderedProminent)
                     .disabled(totalSelectedKanas == 0)
-
-                HStack {
-                    Spacer()
-                    Picker(localized("Training mode"), selection: $kanaSelectionType) {
-                        ForEach(KanaSelectionType.allCases, id: \.self) { Text($0.symbol) }
-                    }
-                    .pickerStyle(.segmented)
-                    .fixedSize()
-                }
             }
             .padding(.horizontal)
             Text(textForSelectedKanas)

--- a/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaSelectionPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/KanaSelection/KanaSelectionPage.swift
@@ -184,7 +184,6 @@ struct BottomViews: View {
                     .disabled(totalSelectedKanas == 0)
 
                 HStack {
-                    Text(localized("Mode"))
                     Spacer()
                     Picker(localized("Training mode"), selection: $kanaSelectionType) {
                         ForEach(KanaSelectionType.allCases, id: \.self) { Text($0.symbol) }

--- a/serena/Kana/Sources/Kana/KanaTraining/LevelUps/PickAnswerPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/LevelUps/PickAnswerPage.swift
@@ -60,7 +60,7 @@ struct PickAnswerPage: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            ProgressView(progress: $progress)
+            ProgressBarView(progress: $progress)
             Text(pickingExerciceType.prompt)
 
             Text(formattedTruth)

--- a/serena/Kana/Sources/Kana/KanaTraining/LevelUps/ProgressBarView.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/LevelUps/ProgressBarView.swift
@@ -1,28 +1,30 @@
 import SwiftUI
 
-struct ProgressView: View {
+struct ProgressBarView: View {
     @Binding var progress: Double
     @State var barColor: Color = .gray
 
-    let barHeight: CGFloat = 30
+    let barHeight: CGFloat = 20
 
     var body: some View {
-        VStack(alignment: .leading) {
+        HStack {
             ZStack(alignment: .leading) {
-                Capsule()
+                Rectangle()
                     .frame(height: barHeight)
                     .foregroundColor(Color.gray.opacity(0.3))
-                    .cornerRadius(10)
 
                 GeometryReader { geometry in
-                    Capsule()
+                    Rectangle()
                         .frame(width: geometry.size.width * progress, height: barHeight)
                         .foregroundStyle(barColor)
-                        .cornerRadius(10)
                 }
             }
             .frame(height: barHeight)
-            Text(progress.formatted(.percent.rounded(increment: 1)))
+            .clipShape(.capsule)
+            ZStack {
+                Text(progress, format: .percent.rounded(increment: 1))
+                Text(100, format: .percent.rounded(increment: 1)).hidden()
+            }
         }
         .onChange(of: progress) { oldValue, newValue in
             if oldValue < newValue {

--- a/serena/Kana/Sources/Kana/KanaTraining/LevelUps/WriteAnswerPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/LevelUps/WriteAnswerPage.swift
@@ -53,7 +53,7 @@ struct WriteAnswerPage: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 10) {
-                ProgressView(progress: $progress)
+                ProgressBarView(progress: $progress)
                 Text(writingExerciceType.prompt)
                 VStack {
                     Text(kanaTruth)
@@ -64,7 +64,6 @@ struct WriteAnswerPage: View {
                         .overlay { RoundedRectangle(cornerRadius: 16).stroke() }
                     Text(info)
                 }
-                Spacer()
 
                 ZStack(alignment: .trailing) {
                     TextEditor(text: $inputText)


### PR DESCRIPTION
The bottom now displays the picker fully,
The progress bar is a rectangle, slimmer and shows the percent on the same line
We now see the whole writing screen at all times even on smaller screens

<img width="320"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-20 at 16 13 34" src="https://github.com/user-attachments/assets/7411b8d1-825e-44e2-9088-b5cf95117063" />
<img width="320"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-20 at 16 07 01" src="https://github.com/user-attachments/assets/e3263814-81a8-4800-aa96-51da401e6402" />
