### PR TITLE
chore: user feedbacks

### DIFF
--- a/serena/Kana/Sources/Kana/KanaMnemonics/DrawingView.swift
+++ b/serena/Kana/Sources/Kana/KanaMnemonics/DrawingView.swift
@@ -65,28 +65,30 @@ public struct DrawingView<ContentView: View>: View {
     }
 
     public var body: some View {
-        contentView()
-            .overlay {
-                driedPath.stroke(driedStrokeColor, style: strokeStyle)
-                currentPath.stroke(driedStrokeColor, style: strokeStyle)
-                wetPath.stroke(wetStrokeColor, style: strokeStyle).opacity(isDrawing ? 1 : 0)
+        VStack(alignment: .leading) {
+            Text(localized("Draw"))
+            contentView()
+                .overlay {
+                    driedPath.stroke(driedStrokeColor, style: strokeStyle)
+                    currentPath.stroke(driedStrokeColor, style: strokeStyle)
+                    wetPath.stroke(wetStrokeColor, style: strokeStyle).opacity(isDrawing ? 1 : 0)
 
-                Circle()
-                    .fill(wetStrokeColor)
-                    .frame(width: isDrawing ? 30 : 0, height: isDrawing ? 30 : 0)
-                    .position(currentPoint)
-                    .animation(.default, value: isDrawing)
-            }
-            .allowsHitTesting(false)
-            .background {
-                Color(white: 0.9)
-                    .gesture(dragGesture)
-                    .allowsHitTesting(true)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-            .padding(24)
-            .onReceive(timer) { _ in updateWetness() }
-        drawingToolBar
+                    Circle()
+                        .fill(wetStrokeColor)
+                        .frame(width: isDrawing ? 30 : 0, height: isDrawing ? 30 : 0)
+                        .position(currentPoint)
+                        .animation(.default, value: isDrawing)
+                }
+                .allowsHitTesting(false)
+                .background {
+                    Color(white: 0.9)
+                        .gesture(dragGesture)
+                        .allowsHitTesting(true)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .onReceive(timer) { _ in updateWetness() }
+            drawingToolBar
+        }
     }
 
     func addPointToCurrent(location: CGPoint) {
@@ -142,7 +144,6 @@ public struct DrawingView<ContentView: View>: View {
             )
             Spacer()
         }
-        .padding(24)
     }
 }
 

--- a/serena/Kana/Sources/Kana/KanaMnemonics/KanaMnemonicsPage.swift
+++ b/serena/Kana/Sources/Kana/KanaMnemonics/KanaMnemonicsPage.swift
@@ -62,7 +62,7 @@ public struct KanaMnemonicsPage: View {
                                     }
                                 } else {
                                     Button(
-                                        localized("Make your own"),
+                                        localized("Draw your own"),
                                         systemImage: "pencil",
                                         action: { onDrawMnemonicTapped(mnemonic: mnemonic) },
                                     )
@@ -150,15 +150,21 @@ struct MnemonicDrawingView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack {
-                    TextField(
-                        localized("Explanation"),
-                        text: $explanationText,
-                        prompt: Text(localized("It reminds me of...")),
-                        axis: .vertical,
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .padding()
+                VStack(spacing: 16) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(localized("Write what the kana reminds you of"))
+                            .typography(.headline)
+                        TextField(
+                            localized("Explanation"),
+                            text: $explanationText,
+                            prompt: Text(localized("It reminds me of...")),
+                            axis: .vertical,
+                        )
+                        .textFieldStyle(.roundedBorder)
+                    }
+                    Divider()
+                        .padding()
+
                     DrawingView(
                         finishedPaths: $drawnPaths,
                         contentView: {
@@ -169,8 +175,9 @@ struct MnemonicDrawingView: View {
                         },
                     )
                 }
+                .padding(24)
             }
-            .navigationTitle(localized("Make your mnemonic for %@", data.kanaString))
+            .navigationTitle(localized("Draw your mnemonic for %@", data.kanaString))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {

--- a/serena/Kana/Sources/Kana/KanaTraining/AllInARow/AllInARowExercicePage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/AllInARow/AllInARowExercicePage.swift
@@ -66,6 +66,7 @@ struct AllInARowExercicePage: View {
                         .textInputAutocapitalization(.never)
                         .multilineTextAlignment(.center)
                         .textEditorStyle(.plain)
+                        .submitLabel(.send)
                         .typography(.title)
                         .focused($isFocused)
 
@@ -107,7 +108,8 @@ struct AllInARowExercicePage: View {
     }
 
     func onSubmit() {
-        let (cleanedText, containsInvalidRomaji) = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let (cleanedText, containsInvalidRomaji) = inputText
+            .filter { !$0.isWhitespace && !$0.isNewline }
             .standardizedRomajiWithWarningInfo
         let convertedTruth = truth.kanaValue.standardisedRomaji
         let isCorrect = cleanedText == convertedTruth

--- a/serena/Kana/Sources/Kana/KanaTraining/LevelUps/WriteAnswerPage.swift
+++ b/serena/Kana/Sources/Kana/KanaTraining/LevelUps/WriteAnswerPage.swift
@@ -75,6 +75,7 @@ struct WriteAnswerPage: View {
                         .textInputAutocapitalization(.never)
                         .multilineTextAlignment(.center)
                         .textEditorStyle(.plain)
+                        .submitLabel(.send)
                         .typography(.title)
                         .focused($isFocused)
 
@@ -126,7 +127,7 @@ struct WriteAnswerPage: View {
     func onSubmit() {
         if !canSubmit { return }
         let (cleanedText, containsInvalidRomaji) = inputText
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .filter { !$0.isWhitespace && !$0.isNewline }
             .standardizedRomajiWithWarningInfo
         let convertedTruth: String = truth.map(\.kanaValue).joined().standardisedRomaji
         let isCorrect = cleanedText == convertedTruth

--- a/serena/Kana/Sources/Kana/Resources/Localizable.xcstrings
+++ b/serena/Kana/Sources/Kana/Resources/Localizable.xcstrings
@@ -142,6 +142,38 @@
         }
       }
     },
+    "Draw" : {
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessine"
+          }
+        }
+      }
+    },
+    "Draw your mnemonic for %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessine ton mnémotechnique pour %@"
+          }
+        }
+      }
+    },
+    "Draw your own" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessine le tien"
+          }
+        }
+      }
+    },
     "Explanation" : {
       "localizations" : {
         "fr" : {
@@ -313,26 +345,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Paliers"
-          }
-        }
-      }
-    },
-    "Make your mnemonic for %@" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crée ton mnémotechnique pour %@"
-          }
-        }
-      }
-    },
-    "Make your own" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crée le tien"
           }
         }
       }
@@ -2166,6 +2178,9 @@
           }
         }
       }
+    },
+    "Write what the kana reminds you of" : {
+
     }
   },
   "version" : "1.1"

--- a/serena/Kana/Sources/Kana/Resources/Localizable.xcstrings
+++ b/serena/Kana/Sources/Kana/Resources/Localizable.xcstrings
@@ -2035,7 +2035,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afficher kana derrière dessin"
+            "value" : "Afficher le kana derrière ton dessin"
           }
         }
       }
@@ -2180,7 +2180,14 @@
       }
     },
     "Write what the kana reminds you of" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrivez ce a quoi le kana vous fait penser"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"


### PR DESCRIPTION
fix: the trimming whitespaces. Now whitespaces and newlines are not taken into account when validating a writing exercice
chore: The return button on writing exercices is now "send" in blue
chore: changed wording on mnemonic creation for clarity