### PR TITLE
[chore] replace double chevron by explicit skip button

### DIFF
--- a/serena/Feature/Training/Sources/Training/Exercices/AllInARow/AllInARowExercicePage.swift
+++ b/serena/Feature/Training/Sources/Training/Exercices/AllInARow/AllInARowExercicePage.swift
@@ -68,7 +68,7 @@ struct AllInARowExercicePage: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .center)
                         .overlay(alignment: .trailing) {
-                            Button("", systemImage: "chevron.forward.2", action: onSkip)
+                            Button(.skip, action: onSkip)
                                 .buttonStyle(.borderless)
                                 .padding()
                         }

--- a/serena/Feature/Training/Sources/Training/Exercices/LevelUps/WriteAnswerPage.swift
+++ b/serena/Feature/Training/Sources/Training/Exercices/LevelUps/WriteAnswerPage.swift
@@ -79,7 +79,7 @@ struct WriteAnswerPage: View {
                                 .typography(.callout)
                         }
                         HStack {
-                            Button("", systemImage: "chevron.forward.2", action: goToNextRound)
+                            Button(.skip, action: goToNextRound)
                                 .buttonStyle(.borderless)
                                 .hidden()
                             Spacer()
@@ -90,7 +90,7 @@ struct WriteAnswerPage: View {
                                 .typography(.largeTitle)
                                 .shake(shakeTrigger)
                             Spacer()
-                            Button("", systemImage: "chevron.forward.2", action: goToNextRound)
+                            Button(.skip, action: goToNextRound)
                                 .buttonStyle(.borderless)
                         }
 


### PR DESCRIPTION
The chevron was confusing and users were tapping on it thinking that they would confirm the kana. This is now clearer